### PR TITLE
refactor(c): move elliptic curve FFI to dedicated file (closes #1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,17 @@ CFLAGS = -O2 -fPIC -I$(PARI_INCLUDE) -I$(LEAN_INCLUDE)
 
 .PHONY: all clean
 
-all: c/pari_lean.o
+C_OBJS = c/pari_lean.o c/pari_ell_lean.o
+
+all: $(C_OBJS)
 	lake build
 
-c/pari_lean.o: c/pari_lean.c
+c/pari_lean.o: c/pari_lean.c c/pari_lean_internal.h
+	gcc $(CFLAGS) -c $< -o $@ $(LDFLAGS)
+
+c/pari_ell_lean.o: c/pari_ell_lean.c c/pari_lean_internal.h
 	gcc $(CFLAGS) -c $< -o $@ $(LDFLAGS)
 
 clean:
-	rm -f c/pari_lean.o
+	rm -f $(C_OBJS)
 	lake clean

--- a/c/pari_ell_lean.c
+++ b/c/pari_ell_lean.c
@@ -1,0 +1,61 @@
+/*
+ * pari_ell_lean.c
+ *
+ * Lean 4 C FFI bindings for PARI elliptic-curve functions.
+ * Separated from pari_lean.c per issue #1.
+ *
+ * Exposed symbols:
+ *   lean_pari_ellinit  —  wraps ellinit()
+ *   lean_pari_ellap    —  wraps ellap()
+ */
+
+#include "pari_lean_internal.h"
+
+/* ================================================================
+ * 1. ellinit のラッパー
+ *    係数文字列 "[a1,a2,a3,a4,a6]" から楕円曲線 GEN を作る
+ * ================================================================ */
+LEAN_EXPORT lean_obj_res lean_pari_ellinit(
+    b_lean_obj_arg coeffs_str,
+    lean_obj_arg world)
+{
+    const char *cstr = lean_string_cstr(coeffs_str);
+    GEN E = NULL;
+    pari_CATCH(CATCH_ALL) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "PARI ellinit error #%ld", err_get_num(__iferr_data));
+        return lean_io_result_mk_error(
+            lean_mk_io_user_error(lean_mk_string(msg)));
+    } pari_TRY {
+        GEN coeffs = gp_read_str(cstr);
+        E = ellinit(coeffs, NULL, DEFAULTPREC);
+    } pari_ENDCATCH;
+    return lean_io_result_mk_ok(gen_to_lean(E));
+}
+
+/* ================================================================
+ * 2. ellap(E, p) — 楕円曲線の Frobenius トレース a_p を計算
+ * ================================================================ */
+LEAN_EXPORT lean_obj_res lean_pari_ellap(
+    b_lean_obj_arg e_obj,
+    b_lean_obj_arg p_obj,
+    lean_obj_arg world)
+{
+    GEN E = lean_to_gen(e_obj);
+    GEN p = lean_to_gen(p_obj);
+    GEN ap = NULL;
+    pari_CATCH(CATCH_ALL) {
+        char msg[64];
+        snprintf(msg, sizeof(msg), "PARI ellap error #%ld", err_get_num(__iferr_data));
+        return lean_io_result_mk_error(
+            lean_mk_io_user_error(lean_mk_string(msg)));
+    } pari_TRY {
+        ap = ellap(E, p);
+    } pari_ENDCATCH;
+    /* ap が small integer か bignum かで変換方法が異なる */
+    if (signe(ap) == 0) {
+        return lean_io_result_mk_ok(lean_int64_to_int(0));
+    }
+    long val = itos(ap);  /* GEN → long（範囲外は PARI がエラー） */
+    return lean_io_result_mk_ok(lean_int64_to_int((int64_t)val));
+}

--- a/c/pari_lean.c
+++ b/c/pari_lean.c
@@ -1,12 +1,12 @@
-#include <lean/lean.h>
-#include <pari/pari.h>
+#include "pari_lean_internal.h"
 #include <string.h>
 
 /* ================================================================
  * 1. External class の登録（GEN ラッパー用）
  * ================================================================ */
 
-static lean_external_class *g_pari_gen_class = NULL;
+/* g_pari_gen_class は pari_ell_lean.c からも参照されるため非 static で定義 */
+lean_external_class *g_pari_gen_class = NULL;
 
 // GEN は PARI の avma スタックが管理するので Lean 側では何もしない
 static void pari_gen_finalize(void *ptr) { (void)ptr; }
@@ -27,18 +27,7 @@ LEAN_EXPORT lean_obj_res lean_pari_initialize(lean_obj_arg world) {
 }
 
 /* ================================================================
- * 3. GEN <-> lean_object* 変換ヘルパー（内部使用）
- * ================================================================ */
-static lean_object *gen_to_lean(GEN x) {
-    return lean_alloc_external(g_pari_gen_class, (void *)x);
-}
-
-static GEN lean_to_gen(lean_object *obj) {
-    return (GEN)lean_get_external_data(obj);
-}
-
-/* ================================================================
- * 4. avma スタック管理
+ * 3. avma スタック管理
  * ================================================================ */
 LEAN_EXPORT lean_obj_res lean_pari_stack_mark(lean_obj_arg world) {
     pari_sp mark = avma;
@@ -58,7 +47,7 @@ LEAN_EXPORT lean_obj_res lean_pari_gcopy(b_lean_obj_arg gen_obj, lean_obj_arg wo
 }
 
 /* ================================================================
- * 5. 文字列パース（gp_read_str 経由）
+ * 4. 文字列パース（gp_read_str 経由）
  * ================================================================ */
 LEAN_EXPORT lean_obj_res lean_pari_read_str(b_lean_obj_arg s, lean_obj_arg world) {
     const char *cstr = lean_string_cstr(s);
@@ -80,7 +69,7 @@ LEAN_EXPORT lean_obj_res lean_pari_read_str(b_lean_obj_arg s, lean_obj_arg world
 }
 
 /* ================================================================
- * 6. GEN を文字列に変換（デバッグ用）
+ * 5. GEN を文字列に変換（デバッグ用）
  * ================================================================ */
 LEAN_EXPORT lean_obj_res lean_pari_tostr(b_lean_obj_arg gen_obj, lean_obj_arg world) {
     GEN x = lean_to_gen(gen_obj);
@@ -88,52 +77,4 @@ LEAN_EXPORT lean_obj_res lean_pari_tostr(b_lean_obj_arg gen_obj, lean_obj_arg wo
     lean_object *result = lean_mk_string(s);
     free(s);
     return lean_io_result_mk_ok(result);
-}
-
-/* ================================================================
- * 7. ellap(E, p) — 楕円曲線の Frobenius トレース
- * ================================================================ */
-LEAN_EXPORT lean_obj_res lean_pari_ellap(
-    b_lean_obj_arg e_obj,
-    b_lean_obj_arg p_obj,
-    lean_obj_arg world)
-{
-    GEN E = lean_to_gen(e_obj);
-    GEN p = lean_to_gen(p_obj);
-    GEN ap = NULL;
-    pari_CATCH(CATCH_ALL) {
-        char msg[64];
-        snprintf(msg, sizeof(msg), "PARI ellap error #%ld", err_get_num(__iferr_data));
-        return lean_io_result_mk_error(
-            lean_mk_io_user_error(lean_mk_string(msg)));
-    } pari_TRY {
-        ap = ellap(E, p);
-    } pari_ENDCATCH;
-    // ap が small integer か bignum かで変換方法が異なる
-    if (signe(ap) == 0) {
-        return lean_io_result_mk_ok(lean_int64_to_int(0));
-    }
-    long val = itos(ap);  // GEN → long（範囲外は PARI がエラー）
-    return lean_io_result_mk_ok(lean_int64_to_int((int64_t)val));
-}
-
-/* ================================================================
- * 8. ellinit のラッパー
- * ================================================================ */
-LEAN_EXPORT lean_obj_res lean_pari_ellinit(
-    b_lean_obj_arg coeffs_str,
-    lean_obj_arg world)
-{
-    const char *cstr = lean_string_cstr(coeffs_str);
-    GEN E = NULL;
-    pari_CATCH(CATCH_ALL) {
-        char msg[64];
-        snprintf(msg, sizeof(msg), "PARI ellinit error #%ld", err_get_num(__iferr_data));
-        return lean_io_result_mk_error(
-            lean_mk_io_user_error(lean_mk_string(msg)));
-    } pari_TRY {
-        GEN coeffs = gp_read_str(cstr);
-        E = ellinit(coeffs, NULL, DEFAULTPREC);
-    } pari_ENDCATCH;
-    return lean_io_result_mk_ok(gen_to_lean(E));
 }

--- a/c/pari_lean_internal.h
+++ b/c/pari_lean_internal.h
@@ -1,0 +1,22 @@
+#pragma once
+/*
+ * pari_lean_internal.h
+ *
+ * Shared helpers used by pari_lean.c and pari_ell_lean.c.
+ * Not part of the public API — do not include from Lean-generated C files.
+ */
+
+#include <lean/lean.h>
+#include <pari/pari.h>
+
+/* External class for GEN — defined in pari_lean.c */
+extern lean_external_class *g_pari_gen_class;
+
+/* GEN <-> lean_object* conversion helpers */
+static inline lean_object *gen_to_lean(GEN x) {
+    return lean_alloc_external(g_pari_gen_class, (void *)x);
+}
+
+static inline GEN lean_to_gen(lean_object *obj) {
+    return (GEN)lean_get_external_data(obj);
+}

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -7,4 +7,4 @@ name = "LeanPari"
 [[lean_exe]]
 name = "Main"
 root = "Main"
-moreLinkArgs = ["-lpari", "-lm", "-L/home/iwao/lib", "-Wl,-rpath,/home/iwao/lib", "c/pari_lean.o"]
+moreLinkArgs = ["-lpari", "-lm", "-L/home/iwao/lib", "-Wl,-rpath,/home/iwao/lib", "c/pari_lean.o", "c/pari_ell_lean.o"]


### PR DESCRIPTION
## Summary

Resolves #1.

Extracts `ellinit` / `ellap` wrappers from `pari_lean.c` into a new dedicated file `c/pari_ell_lean.c`, and introduces a shared internal header `c/pari_lean_internal.h` to expose the GEN conversion helpers across translation units.

## Changes

### New files
- `c/pari_lean_internal.h` — shared internal header declaring `extern g_pari_gen_class` and providing `static inline gen_to_lean()` / `lean_to_gen()`
- `c/pari_ell_lean.c` — dedicated file containing `lean_pari_ellinit` and `lean_pari_ellap`

### Modified files
- `c/pari_lean.c` — include internal header; make `g_pari_gen_class` non-static; remove local helper functions and elliptic sections
- `Makefile` — add `C_OBJS` variable; add build rule for `pari_ell_lean.o` with header dependency
- `lakefile.toml` — add `c/pari_ell_lean.o` to `moreLinkArgs`

## Verification

`lake exec Main` produces the expected output after the restructuring.